### PR TITLE
Change GW/HUB IP so it is in the same subnet

### DIFF
--- a/easy-wg-quick
+++ b/easy-wg-quick
@@ -157,7 +157,7 @@ main() {
     EXT_NET_IP="$(ip addr sh "$EXT_NET_IF" | grep 'inet ' | xargs | \
         awk -F'[ /]' '{ print $2 }')"
     EXT_NET_PORT="51820"
-    INT_NET_HUB_IP="10.127.1.1"
+    INT_NET_HUB_IP="10.127.0.1"
     INT_NET_MASK="/24"
     INT_NET_DNS="1.1.1.1"
     INT_NET_PEER="10.127.0."


### PR DESCRIPTION
HUB was set to 10.127.1.1/24 and clients were put in 10.127.0.0/24.  These are not in the same subnet and would need to be routed to talk to each other.  Unless I am missing something about wireguard, this would be problematic for clients.