### PR TITLE
Add QR image

### DIFF
--- a/easy-wg-quick
+++ b/easy-wg-quick
@@ -406,6 +406,7 @@ print_client_conf() {
 
 print_client_qrcode() {
     qrencode -t ansiutf8 < "wgclient_$1.conf"
+    cat wgclient_$1.conf | qrencode -s 8 -o ./wgclient_$1.png
     echo "Scan QR code with your phone or use \"wgclient_$1.conf\" file."
 }
 


### PR DESCRIPTION
Takes the generated configuration file and saves a QR image that can be retrieved later without running qrencode again.
<img width="573" alt="wg_images" src="https://user-images.githubusercontent.com/23727230/96365186-72204600-1147-11eb-8d6a-36eb1d25ba3a.png">
