### PR TITLE
Use private PSKs for each client instead of a single global key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.bak
 *.conf
 *.key
+*.psk
 *.txt

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Following command will create `wgclient_client_name.conf` file.
 
 ```
 No seqno.txt... creating one!
-No wgpsk.key... creating one!
 No wghub.key... creating one!
 No wghub.conf... creating one!
 Wireguard hub address is 10.13.1.140:51820 on wlp9s0.

--- a/easy-wg-quick
+++ b/easy-wg-quick
@@ -257,11 +257,6 @@ get_ipv6_mode() {
     cat ipv6mode.txt
 }
 
-create_psk() {
-    echo "No wgpsk.key... creating one!"
-    wg genpsk > wgpsk.key
-}
-
 create_hub_key() {
     echo "No wghub.key... creating one!"
     wg genkey > wghub.key
@@ -382,7 +377,7 @@ MTU = $INT_NET_MTU
 
 [Peer]
 PublicKey = $(wg pubkey < wghub.key)
-PresharedKey = $(cat wgpsk.key)
+PresharedKey = $(wg genpsk | tee "wgclient_$CONF_NAME.psk")
 AllowedIPs = $INT_NET_CLINET_ALLOWEDIPS
 Endpoint = $EXT_NET_IP:$EXT_NET_PORT
 PersistentKeepalive = 25
@@ -420,7 +415,7 @@ $(allowedips_to_uci_list "$INT_NET_CLINET_ALLOWEDIPS")
 	option endpoint_port '$EXT_NET_PORT'
 	option persistent_keepalive '25'
 	option public_key '$(wg pubkey < wghub.key)'
-	option preshared_key '$(cat wgpsk.key)'
+	option preshared_key '$(cat "wgclient_$CONF_NAME.psk")'
 EOF
 }
 
@@ -439,7 +434,7 @@ add_client_to_hub_conf() {
 # $SEQNO: $CONF_NAME > wgclient_$CONF_NAME.conf
 [Peer]
 PublicKey = $(wg pubkey < "wgclient_$CONF_NAME.key")
-PresharedKey = $(cat wgpsk.key)
+PresharedKey = $(cat "wgclient_$CONF_NAME.psk")
 AllowedIPs = $INT_NET_ADDRESS$SEQNO$INT_NET_ADDRESS_MASK$($NET6 && echo ", $INT_NET6_ADDRESS$1$INT_NET6_ADDRESS_MASK")
 EOF
     if $NET6 && test "$NET6MODE" = "proxy_ndp"; then
@@ -561,7 +556,6 @@ main() {
     SEQNO="$(get_seq_no)"
     test -f portno.txt || create_port_no
     EXT_NET_PORT="$(get_port_no)"
-    test -f wgpsk.key  || create_psk
     test -f wghub.key  || create_hub_key
     test -f wghub.conf || create_hub_conf
 

--- a/tests/no_global_psk.bats
+++ b/tests/no_global_psk.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load teardown setup
+
+@test "run to check for private psk" {
+    run ../easy-wg-quick private_psk
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -gt 10 ]
+    run test -f wgclient_private_psk.psk
+    [ "$status" -eq 0 ]
+    run test -f wgpsk.key
+    [ "$status" -eq 1 ]
+}

--- a/tests/teardown.bash
+++ b/tests/teardown.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 teardown() {
-    rm -f ./*.bak ./*.conf ./*.key ./*.txt
+    rm -f ./*.bak ./*.conf ./*.key ./*.psk ./*.txt
 }


### PR DESCRIPTION
Easy-wg-quick configures WireGuard to work in an optional pre-shared key mode.
PSK is mixed into the public key cryptography. This patch removes the global
`wgpsk.key` file and switches to using a per-client pre-shared key. After this
change, each client knows only its own PSK.